### PR TITLE
chore(docs): fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,10 +90,10 @@ make devnet-clean
 
 <pre>
 ├── <a href="./contracts/">contracts</a>: Solidity contracts and related software.
-│ ├── <a href="./core/">core/</a>: Core protocol smart contracts.
-│ ├── <a href="./avs/">avs/</a>: Eigen AVS smart contracts.
-│ ├── <a href="./bindings/">bindings/</a>: Go smart contract bindings.
-│ └── <a href="./allocs/">allocs/</a>: Predeploy allocations.
+│ ├── <a href="./contracts/core/">core/</a>: Core protocol smart contracts.
+│ ├── <a href="./contracts/avs/">avs/</a>: Eigen AVS smart contracts.
+│ ├── <a href="./contracts/bindings/">bindings/</a>: Go smart contract bindings.
+│ └── <a href="./contracts/allocs/">allocs/</a>: Predeploy allocations.
 ├── <a href="./docs/">docs</a>: Documentation resources, including images and diagrams.
 ├── <a href="./halo/">halo</a>: The Halo instance, including application logic and attestation mechanisms.
 │ ├── <a href="./halo/app/">app</a>: Application logic for Halo.
@@ -106,7 +106,7 @@ make devnet-clean
 ├── <a href="./relayer/">relayer</a>: Relayer service for cross-chain messages and transactions.
 │ └── <a href="./relayer/app/">app</a>: Application logic for the relayer service.
 ├── <a href="./scripts/">scripts</a>: Utility scripts for development and operational tasks.
-└── <a href="./test/">test</a>: Testing suite for end-to-end, smoke, and utility testing.
+└── <a href="./e2e/test/">test</a>: Testing suite for end-to-end, smoke, and utility testing.
 </pre>
 
 ## Contributing

--- a/contracts/core/README.md
+++ b/contracts/core/README.md
@@ -6,15 +6,15 @@ Omni's core protocol smart contracts.
 
 <pre>
 └── <a href="./src/">src/</a>
-  ├── <a href="./xchain/">xchain/</a>: Cross-chain protocol smart contracts (incl OmniPortal)
-  ├── <a href="./octane/">octane/</a>: Octane protocol smart contracts
-  ├── <a href="./interfaces/">interfaces/</a>: All interfaces
-  ├── <a href="./libraries/">libraries/</a>: All libraries
-  ├── <a href="./pkg/">pkg/</a>: Exported utility contracts
-  ├── <a href="./utils/">utils/</a>: Internal utility contracts
-  ├── <a href="./token/">token/</a>: Token & bridge contracts
-  ├── <a href="./deploy/">deploy/</a>: Deployment utilities
-  └── <a href="./examples/">examples/</a>: Example cross-chain contracts
+  ├── <a href="./src/xchain/">xchain/</a>: Cross-chain protocol smart contracts (incl OmniPortal)
+  ├── <a href="./src/octane/">octane/</a>: Octane protocol smart contracts
+  ├── <a href="./src/interfaces/">interfaces/</a>: All interfaces
+  ├── <a href="./src/libraries/">libraries/</a>: All libraries
+  ├── <a href="./src/pkg/">pkg/</a>: Exported utility contracts
+  ├── <a href="./src/utils/">utils/</a>: Internal utility contracts
+  ├── <a href="./src/token/">token/</a>: Token & bridge contracts
+  ├── <a href="./src/deploy/">deploy/</a>: Deployment utilities
+  └── <a href="./src/examples/">examples/</a>: Example cross-chain contracts
 </pre>
 
 ## Development


### PR DESCRIPTION
Body goes here...

issue: none or #12345

<!--
  PR title and body follows conventional commit; https://www.conventionalcommits.org/en/v1.0.0
  Title template: `type(app/pkg): concise description`
  See allowed types: https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional#type-enum
  Description must be concise: lower case, no punctuation, no more than 50 characters.
  Scope must be concise: only a one or two folders; e.g. 'halo/cmd' or 'github' or '*'
-->
